### PR TITLE
remove CTA from Polling Station info

### DIFF
--- a/components/PollingStationCard.vue
+++ b/components/PollingStationCard.vue
@@ -12,9 +12,6 @@
           }}</span>
           {{ address }}
         </p>
-        <button class="btn btn-sm btn-dark" @click="showStreet = !showStreet">
-          {{ $t('pollingStationCard.seeStreets') }}
-        </button>
       </div>
       <div v-show="showStreet">
         <p class="font-weight-bold mt-4 mb-0">


### PR DESCRIPTION
### What does it fix?

Closes #9 

Removes CTA from Polling Station info card.

### How has it been tested?

Manually tested using dev server.
