### PR TITLE
Update AEP contact email

### DIFF
--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -32,7 +32,7 @@ restrictions on <a href="https://www.posta-romana.ro/a1309/stiri/lista-tarilor-c
     </ul>
     <h4>Important!</h4>
     <p>If you are  missing the ballots or if they have been damaged, you can print them yourself (it is not necessary to print the entire ballot, just the page with your voting preference is enough - if it has the "VOTED" sticker it will be considered a valid vote). You can download the two newsletters from the <a href="https://www.votstrainatate.ro">votstrăinatate.ro</a> website.</p>
-     <p>For any problems you can contact the Permanent Electoral Authority at <a href="mailto:contact@votstrăinatate.ro">contact@votstrainatate.ro</a>.</p>
+     <p>For any problems you can contact the Permanent Electoral Authority at <a href="mailto:contact@votstrainatate.ro">contact@votstrainatate.ro</a>.</p>
     <h4>Step 2: Voting</h4>
     <p>To vote you must:</p>
     <ol>

--- a/lang/ro-RO.js
+++ b/lang/ro-RO.js
@@ -30,7 +30,7 @@ export default {
     </ul>
     <h4>Important!</h4>
     <p>Dacă îți lipsesc buletinele de vot sau dacă au fost deteriorate, le poți printa tu însuți (nu este necesar să printezi tot buletinul de vot, este suficientă pagina pe care este opţiunea ta de vot - dacă are autocolantul cu “VOTAT” se consideră un vot valabil). Poți să descarci cele două buletine de pe site-ul <a href="https://votstrainatate.ro">votstrăinătate.ro</a>.</p>
-    <p>Pentru orice problemă poți contacta Autoritatea Electorală Permanentă la adresa <a href="mailto:contact@votstrăinătate.ro">contact@votstrăinătate.ro</a>.</p>
+    <p>Pentru orice problemă poți contacta Autoritatea Electorală Permanentă la adresa <a href="mailto:contact@votstrainatate.ro">contact@votstrainatate.ro</a>.</p>
 
     <h4>Pasul 2: Votarea</h4>
     <p>Pentru a vota trebuie să:</p>


### PR DESCRIPTION
### What does it fix?
The contact email for AEP contains diacritics which is not the actual email address. This PR updates the email address to the correct form (without diacritics)